### PR TITLE
Enable Bluetooth on kawerna

### DIFF
--- a/hosts/kawerna/default.nix
+++ b/hosts/kawerna/default.nix
@@ -24,7 +24,39 @@
     localNetworkGameTransfers.openFirewall = true;
   };
 
-  # === Graphics ===
+  # =================
+  # vvv Bluetooth vvv
+
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+    settings = {
+      General = {
+        # Shows battery charge of connected devices on supported
+        # Bluetooth adapters. Defaults to 'false'.
+        Experimental = true;
+        # When enabled other devices can connect faster to us, however
+        # the tradeoff is increased power consumption. Defaults to
+        # 'false'.
+        FastConnectable = true;
+      };
+      Policy = {
+        # Enable all controllers when they are found. This includes
+        # adapters present on start as well as adapters that are plugged
+        # in later on. Defaults to 'true'.
+        AutoEnable = true;
+      };
+    };
+  };
+
+  # KDE has its own Bluetooth manager.
+  services.blueman.enable = false;
+
+  # ^^^ Bluetooth ^^^
+  # =================
+
+  # ================
+  # vvv Graphics vvv
   # Lots based on https://nixos.wiki/wiki/Nvidia
 
   # Enable OpenGL
@@ -76,5 +108,8 @@
     # An utility to check if acceleration is working
     libva-utils
   ];
+
+  # ^^^ Graphics ^^^
+  # ================
 
 }


### PR DESCRIPTION
Note: it seems KDE has its own UI Bluetooth manager, so we are not using Blueman